### PR TITLE
Make floating rails work \o/

### DIFF
--- a/src/main/java/com/ewyboy/floatingrails/common/content/FloatingRailBlock.java
+++ b/src/main/java/com/ewyboy/floatingrails/common/content/FloatingRailBlock.java
@@ -7,18 +7,24 @@ import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.BoatEntity;
+import net.minecraft.entity.item.minecart.AbstractMinecartEntity;
 import net.minecraft.fluid.FluidState;
 import net.minecraft.fluid.Fluids;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.shapes.EntitySelectionContext;
+import net.minecraft.util.math.shapes.ISelectionContext;
+import net.minecraft.util.math.shapes.VoxelShape;
+import net.minecraft.util.math.shapes.VoxelShapes;
 import net.minecraft.world.IBlockReader;
 import net.minecraft.world.IWorldReader;
 import net.minecraft.world.World;
 import net.minecraft.world.server.ServerWorld;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public class FloatingRailBlock extends RailBlock implements IHasRenderType, ContentLoader.IHasNoBlockItem {
 
     public FloatingRailBlock() {
-        super(AbstractBlock.Properties.of(Material.DECORATION).noCollission().strength(0.7F).sound(SoundType.METAL));
+        super(AbstractBlock.Properties.of(Material.DECORATION).strength(0.7F).sound(SoundType.METAL));
     }
 
     @Override
@@ -27,6 +33,16 @@ public class FloatingRailBlock extends RailBlock implements IHasRenderType, Cont
         if (world instanceof ServerWorld && entity instanceof BoatEntity) {
             world.destroyBlock(new BlockPos(pos), true, entity);
         }
+    }
+
+    @Override
+    public VoxelShape getCollisionShape(BlockState state, IBlockReader world, BlockPos pos, ISelectionContext ctx) {
+        // Set collision for minecarts to be empty but other entities are still able to walk on it like on lily pads
+        if (ctx.getEntity() instanceof AbstractMinecartEntity) {
+            return VoxelShapes.empty();
+        }
+
+        return super.getCollisionShape(state, world, pos, ctx);
     }
 
     @Override

--- a/src/main/java/com/ewyboy/floatingrails/util/EventHandler.java
+++ b/src/main/java/com/ewyboy/floatingrails/util/EventHandler.java
@@ -1,53 +1,45 @@
 package com.ewyboy.floatingrails.util;
 
 import com.ewyboy.floatingrails.register.Register;
-import net.minecraft.block.BlockState;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.item.minecart.AbstractMinecartEntity;
-import net.minecraft.tags.BlockTags;
 import net.minecraft.util.DamageSource;
+import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.MathHelper;
 import net.minecraftforge.event.entity.living.LivingAttackEvent;
-import net.minecraftforge.event.entity.living.LivingHurtEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public class EventHandler {
 
     @SubscribeEvent
-    public static void onDamage(LivingAttackEvent event)  {
-
+    public static void onDamage(LivingAttackEvent event) {
         LivingEntity entity = event.getEntityLiving();
         DamageSource damageSource = event.getSource();
-
         if (damageSource == DamageSource.ON_FIRE || damageSource == DamageSource.LAVA) {
-
             if (entity.isPassenger()) {
-
                 Entity minecart = entity.getVehicle();
-
                 if (minecart instanceof AbstractMinecartEntity) {
-                    int x = MathHelper.floor(minecart.getX());
-                    int y = MathHelper.floor(minecart.getY());
-                    int z = MathHelper.floor(minecart.getZ());
-
-                    if (minecart.level.getBlockState(new BlockPos(x, y - 1, z)).is(BlockTags.RAILS)) {
-                        --y;
+                    AxisAlignedBB aabb = entity.getBoundingBox();
+                    // Look through all the blockposes that our passenger occupies to see if they
+                    // collide with the obsidian lily rail.
+                    // This is not ideal but without mixins it might not be possible.
+                    boolean foundRail = false;
+                    for (int x = (int) Math.floor(aabb.minX); x < Math.ceil(aabb.maxX); x++) {
+                        for (int z = (int) Math.floor(aabb.minZ); z < Math.ceil(aabb.maxZ); z++) {
+                            for (int y = (int) Math.floor(aabb.minY); y < Math.ceil(aabb.maxY); y++) {
+                                BlockPos pos = new BlockPos(x, y, z);
+                                if (minecart.level.getBlockState(pos).is(Register.BLOCK.FLOATING_RAIL_LAVA)) {
+                                    foundRail = true;
+                                }
+                            }
+                        }
                     }
 
-                    BlockPos blockpos = new BlockPos(x, y, z);
-                    BlockState blockstate = minecart.level.getBlockState(blockpos);
-
-                    if (blockstate.is(Register.BLOCK.FLOATING_RAIL_LAVA)) {
-
-                        ModLogger.info("Damage src :: " + damageSource);
-
+                    if (foundRail) {
                         if (entity.isOnFire()) {
                             entity.setRemainingFireTicks(0);
                         }
-
-                        ModLogger.info("onDamage() :: Canceled");
                         event.setCanceled(true);
                     }
                 }

--- a/src/main/resources/assets/floatingrails/lang/en_us.json
+++ b/src/main/resources/assets/floatingrails/lang/en_us.json
@@ -1,19 +1,6 @@
 {
-  "itemGroup.itank": "ITank",
-  "item.itank.tank": "Liquid Tank",
-  "item.itank.tank_white": "Liquid Tank",
-  "item.itank.tank_red": "Liquid Tank",
-  "item.itank.tank_orange": "Liquid Tank",
-  "item.itank.tank_pink": "Liquid Tank",
-  "item.itank.tank_yellow": "Liquid Tank",
-  "item.itank.tank_lime": "Liquid Tank",
-  "item.itank.tank_green": "Liquid Tank",
-  "item.itank.tank_light_blue": "Liquid Tank",
-  "item.itank.tank_cyan": "Liquid Tank",
-  "item.itank.tank_blue": "Liquid Tank",
-  "item.itank.tank_magenta": "Liquid Tank",
-  "item.itank.tank_purple": "Liquid Tank",
-  "item.itank.tank_brown": "Liquid Tank",
-  "item.itank.tank_light_gray": "Liquid Tank",
-  "item.itank.tank_black": "Liquid Tank"
+    "block.floatingrails.magma_lily": "Magma Lily",
+    "block.floatingrails.floating_rail": "Lily Pad Rail",
+    "block.floatingrails.floating_rail_lava": "Magma Lily Rail",
+    "itemGroup.floatingrails": "Floating Rails"
 }


### PR DESCRIPTION
Entities in minecarts on magma lily rails no longer take damage due to technically being in lava while riding the minecart.
The floating rails now have proper collision which allows entities to walk on them like they would for their non-rail equivalent.